### PR TITLE
 Added icon label overlay functionality

### DIFF
--- a/dungeon.js
+++ b/dungeon.js
@@ -96,10 +96,10 @@ var cellMarkTypes = {
 var labelFillTypes = {
     "white": "#ffffff",
     "ex_yellow": "#eeeecc",
-	"sel_yellow": "#ffff77",
-	"tp_cyan": "#34ddff",
-	"red": "#ff0000",
-	"black": "#000000"
+    "sel_yellow": "#ffff77",
+    "tp_cyan": "#34ddff",
+    "red": "#ff0000",
+    "black": "#000000"
 };
 var edgeTypes = {"wall": "#444444"};//, "door": "#ffaaff"};
 var edgeMarkTypes = {
@@ -240,7 +240,7 @@ function handleClick(event) {
 
 function handleRightClick(event) {
     
-	// place marker
+    // place marker
     event.preventDefault();
     
     var clickX = event.pageX - canvas.offsetLeft;
@@ -248,29 +248,29 @@ function handleRightClick(event) {
     
     var x = Math.floor(clickX / PX_CELL);
     var y = Math.floor(clickY / PX_CELL);
-	
-	if (clickX % PX_CELL <= PX_EDGE_TOLERANCE/2) {
-		handleVertEdge(x, y, null, currentEdgeMark);
-	} else if (PX_CELL - clickX % PX_CELL <= PX_EDGE_TOLERANCE/2) {
-		// clicked on left half
-		handleVertEdge(x+1, y, null, currentEdgeMark);
-	} else if (clickY % PX_CELL <= PX_EDGE_TOLERANCE/2) {
-		handleHorizEdge(x, y, null, currentEdgeMark);
-	} else if (PX_CELL - clickY % PX_CELL <= PX_EDGE_TOLERANCE/2) {
-		// clicked on top half
-		handleHorizEdge(x, y+1, null, currentEdgeMark);
-	} else {
-		// Handle cell contents
-		
-		// Ctrl is held down: add a text label using the value in the Icon Label field
-		if (event.ctrlKey) {
-			handleCell(x, y, null, null, document.getElementById("icon_label_text").value, currentLabelFill);
-		}
-		// Ctrl is not held down: place an icon
-		else {
-			handleCell(x, y, null, currentCellMark, null, null);
-		}
-	}
+    
+    if (clickX % PX_CELL <= PX_EDGE_TOLERANCE/2) {
+        handleVertEdge(x, y, null, currentEdgeMark);
+    } else if (PX_CELL - clickX % PX_CELL <= PX_EDGE_TOLERANCE/2) {
+        // clicked on left half
+        handleVertEdge(x+1, y, null, currentEdgeMark);
+    } else if (clickY % PX_CELL <= PX_EDGE_TOLERANCE/2) {
+        handleHorizEdge(x, y, null, currentEdgeMark);
+    } else if (PX_CELL - clickY % PX_CELL <= PX_EDGE_TOLERANCE/2) {
+        // clicked on top half
+        handleHorizEdge(x, y+1, null, currentEdgeMark);
+    } else {
+        // Handle cell contents
+        
+        // Ctrl is held down: add a text label using the value in the Icon Label field
+        if (event.ctrlKey) {
+            handleCell(x, y, null, null, document.getElementById("icon_label_text").value, currentLabelFill);
+        }
+        // Ctrl is not held down: place an icon
+        else {
+            handleCell(x, y, null, currentCellMark, null, null);
+        }
+    }
 }
 
 function handleDoubleClick(event) {
@@ -423,18 +423,18 @@ function handleCell(x, y, cellType, mark, label, labelFill) {
         "y": y,
         "value": cellType,
         "mark": mark,
-		"label": label,
-		"labelFill": labelFill
+        "label": label,
+        "labelFill": labelFill
     };
-	
+    
     // Copy old values (if changing bg or fg only)
     if (old != null) {
         if (cellType == null) point.value = old.value;
         if (mark == null) point.mark = old.mark;
         if (label == null) {
-			point.label = old.label;
-			point.labelFill = old.labelFill;
-		}
+            point.label = old.label;
+            point.labelFill = old.labelFill;
+        }
     }
 
     data[currentFloor].cells.push(point);
@@ -578,15 +578,15 @@ function createPalette() {
         ul.appendChild(li);
     }
     cellMarkDiv.appendChild(ul);
-	
-	// Label Fill Colors
-	var labelFillDiv = document.getElementById("label_fill_colors");
+    
+    // Label Fill Colors
+    var labelFillDiv = document.getElementById("label_fill_colors");
     labelFillDiv.innerHTML = "";
-	    for (const [key, value] of Object.entries(labelFillTypes)) {
+        for (const [key, value] of Object.entries(labelFillTypes)) {
         var btn = document.createElement("button");
         btn.setAttribute("onclick", "changeSelectedLabelFill('" + key + "')");
         //btn.innerHTML = key;
-		btn.name = key;
+        btn.name = key;
         if (isDarkColor(value)) {
             btn.style = "background-color: " + value + "; color:white";
         } else {
@@ -598,7 +598,7 @@ function createPalette() {
             btn.classList.add("current");
         }
     }
-	
+    
     // Edge Marks
     var edgeMarkDiv = document.getElementById("edgemarks");
     edgeMarkDiv.innerHTML = "";
@@ -1122,8 +1122,8 @@ function drawEdgeMark(xpx, ypx, pt) {
 function drawCell(pt) {
     var xpx = pt.x * PX_CELL;
     var ypx = pt.y * PX_CELL;
-	
-	// Fill in the cell with the tile color
+    
+    // Fill in the cell with the tile color
     if (pt.value != null && cellTypes[pt.value] != null) {
         ctx.fillStyle = cellTypes[pt.value];
         // commented to fill whole cell
@@ -1134,7 +1134,7 @@ function drawCell(pt) {
             PX_CELL);// - PX_WALL_WIDTH);
     }
     
-	// Draw the tile icon
+    // Draw the tile icon
     if (pt.mark != null && cellMarkTypes[pt.mark] != null) {
         var img = new Image();
         img.onload = function() {
@@ -1142,36 +1142,36 @@ function drawCell(pt) {
             var imgy = ypx + (PX_CELL-CELL_IMG_HEIGHT)/2;
             ctx.drawImage(img, imgx, imgy, CELL_IMG_WIDTH, CELL_IMG_HEIGHT);
             img = null;
-			
-			// Draw the tile label
-			drawLabel(pt);
+            
+            // Draw the tile label
+            drawLabel(pt);
         };
         img.src = cellMarkTypes[pt.mark];
     }
-	// No marker is drawn
-	else {
-		// Draw the tile label
-		drawLabel(pt);
-	}
+    // No marker is drawn
+    else {
+        // Draw the tile label
+        drawLabel(pt);
+    }
 }
 
 function drawLabel(pt) {
-	if (pt.label != null) {
-		var xOff = ((pt.x + 1)*PX_CELL)-PX_WALL_WIDTH;
-		var yOff = ((pt.y + 1)*PX_CELL)-PX_WALL_WIDTH;
-		var filcol = labelFillTypes[pt.labelFill];
-		
-		ctx.font = '18px WerdnasReturn, Do Hyeon, Courier, sans-serif';
-		ctx.textAlign = "right";
-		
-		ctx.strokeStyle = isDarkColor(filcol) ? "#ffffff" : "#000000";
-		ctx.lineWidth = 4;
-		ctx.strokeText(pt.label, xOff, yOff, PX_CELL);
-		
-		ctx.fillStyle = filcol;
-		ctx.fillText(pt.label, xOff, yOff, PX_CELL);
-		
-	}
+    if (pt.label != null) {
+        var xOff = ((pt.x + 1)*PX_CELL)-PX_WALL_WIDTH;
+        var yOff = ((pt.y + 1)*PX_CELL)-PX_WALL_WIDTH;
+        var filcol = labelFillTypes[pt.labelFill];
+        
+        ctx.font = '18px WerdnasReturn, Do Hyeon, Courier, sans-serif';
+        ctx.textAlign = "right";
+        
+        ctx.strokeStyle = isDarkColor(filcol) ? "#ffffff" : "#000000";
+        ctx.lineWidth = 4;
+        ctx.strokeText(pt.label, xOff, yOff, PX_CELL);
+        
+        ctx.fillStyle = filcol;
+        ctx.fillText(pt.label, xOff, yOff, PX_CELL);
+        
+    }
 }
 
 //////////////////////////////////////////////////

--- a/dungeon.js
+++ b/dungeon.js
@@ -239,7 +239,6 @@ function handleClick(event) {
 }
 
 function handleRightClick(event) {
-    
     // place marker
     event.preventDefault();
     
@@ -262,12 +261,11 @@ function handleRightClick(event) {
     } else {
         // Handle cell contents
         
-        // Ctrl is held down: add a text label using the value in the Icon Label field
         if (event.ctrlKey) {
+			// Ctrl is held down: add a text label using the value in the Icon Label field
             handleCell(x, y, null, null, document.getElementById("icon_label_text").value, currentLabelFill);
-        }
-        // Ctrl is not held down: place an icon
-        else {
+        } else {
+			// Ctrl is not held down: place an icon
             handleCell(x, y, null, currentCellMark, null, null);
         }
     }
@@ -585,13 +583,8 @@ function createPalette() {
         for (const [key, value] of Object.entries(labelFillTypes)) {
         var btn = document.createElement("button");
         btn.setAttribute("onclick", "changeSelectedLabelFill('" + key + "')");
-        //btn.innerHTML = key;
         btn.name = key;
-        if (isDarkColor(value)) {
-            btn.style = "background-color: " + value + "; color:white";
-        } else {
-            btn.style = "background-color: " + value + "; color:black";
-        }
+        btn.style = "background-color: " + value + ";";
         labelFillDiv.appendChild(btn);
 
         if (key == currentLabelFill) {
@@ -1147,10 +1140,8 @@ function drawCell(pt) {
             drawLabel(pt);
         };
         img.src = cellMarkTypes[pt.mark];
-    }
-    // No marker is drawn
-    else {
-        // Draw the tile label
+    } else {
+		// No marker is drawn - draw the title label
         drawLabel(pt);
     }
 }

--- a/dungeon.js
+++ b/dungeon.js
@@ -262,10 +262,10 @@ function handleRightClick(event) {
         // Handle cell contents
         
         if (event.ctrlKey) {
-			// Ctrl is held down: add a text label using the value in the Icon Label field
+            // Ctrl is held down: add a text label using the value in the Icon Label field
             handleCell(x, y, null, null, document.getElementById("icon_label_text").value, currentLabelFill);
         } else {
-			// Ctrl is not held down: place an icon
+            // Ctrl is not held down: place an icon
             handleCell(x, y, null, currentCellMark, null, null);
         }
     }
@@ -1141,7 +1141,7 @@ function drawCell(pt) {
         };
         img.src = cellMarkTypes[pt.mark];
     } else {
-		// No marker is drawn - draw the title label
+        // No marker is drawn - draw the title label
         drawLabel(pt);
     }
 }

--- a/dungeon.js
+++ b/dungeon.js
@@ -93,6 +93,14 @@ var cellMarkTypes = {
     "monster": "markers/monster.png",
     "pressF": "markers/pressF.png"
 };
+var labelFillTypes = {
+    "white": "#ffffff",
+    "ex_yellow": "#eeeecc",
+	"sel_yellow": "#ffff77",
+	"tp_cyan": "#34ddff",
+	"red": "#ff0000",
+	"black": "#000000"
+};
 var edgeTypes = {"wall": "#444444"};//, "door": "#ffaaff"};
 var edgeMarkTypes = {
     "door": "markers/door_v.png",
@@ -108,6 +116,7 @@ var edgeMarkTypes = {
 var currentFloor = 0;
 var currentCellType = Object.entries(cellTypes)[0][0];
 var currentCellMark = Object.entries(cellMarkTypes)[0][0];
+var currentLabelFill = Object.entries(labelFillTypes)[0][0];
 var currentEdgeType = Object.entries(edgeTypes)[0][0];
 var currentEdgeMark = Object.entries(edgeMarkTypes)[0][0];
 
@@ -225,12 +234,13 @@ function handleClick(event) {
         // clicked on top half
         handleHorizEdge(x, y+1, currentEdgeType, null);
     } else {
-        handleCell(x, y, currentCellType, null);
+        handleCell(x, y, currentCellType, null, null, null);
     }
 }
 
 function handleRightClick(event) {
-    // place marker
+    
+	// place marker
     event.preventDefault();
     
     var clickX = event.pageX - canvas.offsetLeft;
@@ -238,20 +248,29 @@ function handleRightClick(event) {
     
     var x = Math.floor(clickX / PX_CELL);
     var y = Math.floor(clickY / PX_CELL);
-
-    if (clickX % PX_CELL <= PX_EDGE_TOLERANCE/2) {
-        handleVertEdge(x, y, null, currentEdgeMark);
-    } else if (PX_CELL - clickX % PX_CELL <= PX_EDGE_TOLERANCE/2) {
-        // clicked on left half
-        handleVertEdge(x+1, y, null, currentEdgeMark);
-    } else if (clickY % PX_CELL <= PX_EDGE_TOLERANCE/2) {
-        handleHorizEdge(x, y, null, currentEdgeMark);
-    } else if (PX_CELL - clickY % PX_CELL <= PX_EDGE_TOLERANCE/2) {
-        // clicked on top half
-        handleHorizEdge(x, y+1, null, currentEdgeMark);
-    } else {
-        handleCell(x, y, null, currentCellMark);
-    }
+	
+	if (clickX % PX_CELL <= PX_EDGE_TOLERANCE/2) {
+		handleVertEdge(x, y, null, currentEdgeMark);
+	} else if (PX_CELL - clickX % PX_CELL <= PX_EDGE_TOLERANCE/2) {
+		// clicked on left half
+		handleVertEdge(x+1, y, null, currentEdgeMark);
+	} else if (clickY % PX_CELL <= PX_EDGE_TOLERANCE/2) {
+		handleHorizEdge(x, y, null, currentEdgeMark);
+	} else if (PX_CELL - clickY % PX_CELL <= PX_EDGE_TOLERANCE/2) {
+		// clicked on top half
+		handleHorizEdge(x, y+1, null, currentEdgeMark);
+	} else {
+		// Handle cell contents
+		
+		// Ctrl is held down: add a text label using the value in the Icon Label field
+		if (event.ctrlKey) {
+			handleCell(x, y, null, null, document.getElementById("icon_label_text").value, currentLabelFill);
+		}
+		// Ctrl is not held down: place an icon
+		else {
+			handleCell(x, y, null, currentCellMark, null, null);
+		}
+	}
 }
 
 function handleDoubleClick(event) {
@@ -385,7 +404,7 @@ function handleHorizEdge(x, y, edgeType, mark) {
     drawEdge(point);
 }
 
-function handleCell(x, y, cellType, mark) {
+function handleCell(x, y, cellType, mark, label, labelFill) {
     // Find old value if exists
     var old;
     for (i = 0; i < data[currentFloor].cells.length; i++) {
@@ -403,13 +422,19 @@ function handleCell(x, y, cellType, mark) {
         "x": x,
         "y": y,
         "value": cellType,
-        "mark": mark
+        "mark": mark,
+		"label": label,
+		"labelFill": labelFill
     };
-
+	
     // Copy old values (if changing bg or fg only)
     if (old != null) {
         if (cellType == null) point.value = old.value;
         if (mark == null) point.mark = old.mark;
+        if (label == null) {
+			point.label = old.label;
+			point.labelFill = old.labelFill;
+		}
     }
 
     data[currentFloor].cells.push(point);
@@ -553,7 +578,27 @@ function createPalette() {
         ul.appendChild(li);
     }
     cellMarkDiv.appendChild(ul);
+	
+	// Label Fill Colors
+	var labelFillDiv = document.getElementById("label_fill_colors");
+    labelFillDiv.innerHTML = "";
+	    for (const [key, value] of Object.entries(labelFillTypes)) {
+        var btn = document.createElement("button");
+        btn.setAttribute("onclick", "changeSelectedLabelFill('" + key + "')");
+        //btn.innerHTML = key;
+		btn.name = key;
+        if (isDarkColor(value)) {
+            btn.style = "background-color: " + value + "; color:white";
+        } else {
+            btn.style = "background-color: " + value + "; color:black";
+        }
+        labelFillDiv.appendChild(btn);
 
+        if (key == currentLabelFill) {
+            btn.classList.add("current");
+        }
+    }
+	
     // Edge Marks
     var edgeMarkDiv = document.getElementById("edgemarks");
     edgeMarkDiv.innerHTML = "";
@@ -638,6 +683,22 @@ function changeSelectedCellMark(t) {
     }
 
     currentCellMark = t;
+}
+
+function changeSelectedLabelFill(t) {
+    // Update button
+    var labelFillColorsDiv = document.getElementById("label_fill_colors");
+    labelFillColorsDiv.getElementsByClassName("current")[0].classList.remove("current");
+
+    var btns = labelFillColorsDiv.getElementsByTagName("button");
+    for (i = 0; i < btns.length; i++) {
+        if (btns[i].name == t) {
+            btns[i].classList.add("current");
+            break;
+        }
+    }
+
+    currentLabelFill = t;
 }
 
 // function changeSelectedEdgeType(t) {
@@ -1061,7 +1122,8 @@ function drawEdgeMark(xpx, ypx, pt) {
 function drawCell(pt) {
     var xpx = pt.x * PX_CELL;
     var ypx = pt.y * PX_CELL;
-
+	
+	// Fill in the cell with the tile color
     if (pt.value != null && cellTypes[pt.value] != null) {
         ctx.fillStyle = cellTypes[pt.value];
         // commented to fill whole cell
@@ -1072,6 +1134,7 @@ function drawCell(pt) {
             PX_CELL);// - PX_WALL_WIDTH);
     }
     
+	// Draw the tile icon
     if (pt.mark != null && cellMarkTypes[pt.mark] != null) {
         var img = new Image();
         img.onload = function() {
@@ -1079,9 +1142,36 @@ function drawCell(pt) {
             var imgy = ypx + (PX_CELL-CELL_IMG_HEIGHT)/2;
             ctx.drawImage(img, imgx, imgy, CELL_IMG_WIDTH, CELL_IMG_HEIGHT);
             img = null;
+			
+			// Draw the tile label
+			drawLabel(pt);
         };
         img.src = cellMarkTypes[pt.mark];
     }
+	// No marker is drawn
+	else {
+		// Draw the tile label
+		drawLabel(pt);
+	}
+}
+
+function drawLabel(pt) {
+	if (pt.label != null) {
+		var xOff = ((pt.x + 1)*PX_CELL)-PX_WALL_WIDTH;
+		var yOff = ((pt.y + 1)*PX_CELL)-PX_WALL_WIDTH;
+		var filcol = labelFillTypes[pt.labelFill];
+		
+		ctx.font = '18px WerdnasReturn, Do Hyeon, Courier, sans-serif';
+		ctx.textAlign = "right";
+		
+		ctx.strokeStyle = isDarkColor(filcol) ? "#ffffff" : "#000000";
+		ctx.lineWidth = 4;
+		ctx.strokeText(pt.label, xOff, yOff, PX_CELL);
+		
+		ctx.fillStyle = filcol;
+		ctx.fillText(pt.label, xOff, yOff, PX_CELL);
+		
+	}
 }
 
 //////////////////////////////////////////////////

--- a/index.html
+++ b/index.html
@@ -49,7 +49,15 @@
             
             <h3>Tile Icons</h3>
             <div id="cellmarks"></div>
-
+			
+			<div id="icon_labels">
+				<h3>Icon Label</h3>
+				<input id="icon_label_text" type="text" maxlength="2" size="2" />
+				<br />
+				<h3>Fills</h3>
+				<div id="label_fill_colors"></div>
+			</div>
+			
             <h3>Wall Icons</h3>
             <div id="edgemarks"></div>
         </div>
@@ -74,6 +82,7 @@
             <ul>
                 <li>Left click: Place (or replace) tile or wall</li>
                 <li>Right click: Place (or replace) icon</li>
+                <li>Ctrl + Right click: Place (or replace) icon label</li>
                 <li>Double click: Clear tile or wall and its icons</li>
             </ul>
             <input id="darkmode" type="checkbox" onClick="toggleTheme()">&nbsp;Dark Mode</input>

--- a/index.html
+++ b/index.html
@@ -49,15 +49,15 @@
             
             <h3>Tile Icons</h3>
             <div id="cellmarks"></div>
-			
-			<div id="icon_labels">
-				<h3>Icon Label</h3>
-				<input id="icon_label_text" type="text" maxlength="2" size="2" />
-				<br />
-				<h3>Fills</h3>
-				<div id="label_fill_colors"></div>
-			</div>
-			
+            
+            <div id="icon_labels">
+                <h3>Icon Label</h3>
+                <input id="icon_label_text" type="text" maxlength="2" size="2" />
+                <br />
+                <h3>Fills</h3>
+                <div id="label_fill_colors"></div>
+            </div>
+            
             <h3>Wall Icons</h3>
             <div id="edgemarks"></div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -133,6 +133,10 @@ label {
     display:inline;
 }
 
+#help li{
+	padding-bottom:8px;
+}
+
 #palette li, #config li {
     display:inline;
 }
@@ -167,6 +171,16 @@ button#savebtn {
 #cellmarks img.current, #edgemarks img.current, #cellmarkconfig img.current, #edgemarkconfig img.current {
     background-color: var(--color-btn-accent);
     padding:0px;
+}
+
+#icon_labels h3, #icon_labels div {
+    padding-right:5px;
+	display:inline;
+}
+
+#label_fill_colors button {
+	width:20px;
+	height:20px;
 }
 
 #edgemarks img, #edgemarkconfig img {

--- a/styles.css
+++ b/styles.css
@@ -134,7 +134,7 @@ label {
 }
 
 #help li{
-	padding-bottom:8px;
+    padding-bottom:8px;
 }
 
 #palette li, #config li {
@@ -175,12 +175,12 @@ button#savebtn {
 
 #icon_labels h3, #icon_labels div {
     padding-right:5px;
-	display:inline;
+    display:inline;
 }
 
 #label_fill_colors button {
-	width:20px;
-	height:20px;
+    width:20px;
+    height:20px;
 }
 
 #edgemarks img, #edgemarkconfig img {


### PR DESCRIPTION
-Added Icon Label field that accepts up to two characters
-Added Fills color palette
-Control+Right Click adds or replaces icon labels on a given tile
-Added help instructions for Ctrl+Right Click
-Added spacing between help instruction entries