### PR TITLE
Add adjustable floor size

### DIFF
--- a/data/samplemap.json
+++ b/data/samplemap.json
@@ -7,7 +7,7 @@
     },
     "cellTypes": {
       "explored": "#eeeecc",
-      "rock": "#444444",
+      "rock": "#555555",
       "water": "#47a2e1",
       "darkness": "#6257b3"
     },

--- a/dungeon.js
+++ b/dungeon.js
@@ -151,12 +151,6 @@ window.onload = function() {
     canvas.onselectstart = function () { return false; }
 }
 
-function redrawCanvas() {
-    canvas.width = WIDTH*PX_CELL;
-    canvas.height = HEIGHT*PX_CELL;
-    drawGrid();
-}
-
 function toggleTheme() {
     var isDark = document.getElementById("darkmode").checked;
     var theme = isDark ? "theme-dark" : "theme-light"
@@ -979,6 +973,12 @@ function moveRight() {
 
 //////////////////////////////////////////////////
 // Map Drawing
+
+function redrawCanvas() {
+    canvas.width = WIDTH*PX_CELL;
+    canvas.height = HEIGHT*PX_CELL;
+    drawGrid();
+}
 
 function redrawMap() {
     // Clear and re-draw with current data

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                 <!-- <li><button onclick="newCellType()">New Tile Type</button></li> -->
                 <li><button onclick="showConfig()">Configure Map</button></li>
                 <li><a class="button" id="exportLink" onClick="exportMap()">Export Map File</a></li>
-                <li><button class="warningbtn" onclick="clearMap()" title="Wipes the current map. This cannot be undone!">Clear Map</button></li>
+                <li><button class="warning" onclick="clearMap()" title="Wipes the current map. This cannot be undone!">Clear Map</button></li>
             </ul>
             <div id="links">
                 <input type="file" id="uploadfile" onchange="enableLoad()" />
@@ -93,7 +93,7 @@
 <div id="config-modal">
     <div class="content">
         <h1>Map configuration</h1>
-        <p><b><font color="red">Warning:</font></b> Deleting tiles/icons here, or reducing the number of floors or tile side length, will <b>delete</b> any points of those types in your map!</p>
+        <p><span class="warning">Warning:</span> Deleting tiles/icons here, or reducing the number of floors or tile side length, will <b>delete</b> any points of those types in your map!</p>
         <hr/>
         Number of floors: <input id="numfloors" type="number" value="10" min="1"/>
 		<br/>
@@ -121,7 +121,7 @@
         <br/>
         <hr/>
         <button onclick="hideConfig()">Cancel</button>
-        <button class="warningbtn" onclick="saveConfig()">Apply Changes</button>
+        <button class="warning" onclick="saveConfig()">Apply Changes</button>
     </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -66,9 +66,9 @@
             <h3>Move Map</h3>
             <table>
                 <tr>
-                    <td><img class="rotate" title="rotate CCW" onclick="rotateLeft()" src="icons/rotate_ccw.png" /></td>
+                    <td><img class="rotate" title="rotate CCW" onclick="rotateCounterClockwise()" src="icons/rotate_ccw.png" /></td>
                     <td><img title="translate up" onclick="moveUp()" src="icons/arrow_up.png" /></td>
-                    <td><img class="rotate" title="rotate CW" onclick="rotateRight()" src="icons/rotate_cw.png" /></td>
+                    <td><img class="rotate" title="rotate CW" onclick="rotateClockwise()" src="icons/rotate_cw.png" /></td>
                 </tr>
                 <tr>
                     <td><img title="translate left" onclick="moveLeft()" src="icons/arrow_left.png" /></td>
@@ -93,9 +93,11 @@
 <div id="config-modal">
     <div class="content">
         <h1>Map configuration</h1>
-        <p><b>Warning:</b> Deleting tiles or icons here or reducing the number of floors will delete any points of those types in your map!</p>
+        <p><b><font color="red">Warning:</font></b> Deleting tiles/icons here, or reducing the number of floors or tile side length will <b>delete</b> any points of those types in your map!</p>
         <hr/>
-        Number of floors: <input id="numfloors" type="number" value="1" min="1"/>
+        Number of floors: <input id="numfloors" type="number" value="10" min="1"/>
+		<br/>
+        Tile side length: <input id="sidelength" type="number" value="20" min="1"/>
         <hr/>
         <h2>Tile Types</h2>
         <div id="cellconfig">

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 <div id="config-modal">
     <div class="content">
         <h1>Map configuration</h1>
-        <p><b><font color="red">Warning:</font></b> Deleting tiles/icons here, or reducing the number of floors or tile side length will <b>delete</b> any points of those types in your map!</p>
+        <p><b><font color="red">Warning:</font></b> Deleting tiles/icons here, or reducing the number of floors or tile side length, will <b>delete</b> any points of those types in your map!</p>
         <hr/>
         Number of floors: <input id="numfloors" type="number" value="10" min="1"/>
 		<br/>

--- a/styles.css
+++ b/styles.css
@@ -244,10 +244,11 @@ button#savebtn {
 #floors button.current {
     padding:3px;
 }
-
-.warningbtn {
+button.warning {
+    float: right;
+}
+.warning {
     color: var(--color-err);
-    float:right;
 }
 
 #footer {


### PR DESCRIPTION
Adds a `Configure Map` option for the user to change the size of the floor.
The size is always square, and all floors use the same size.

I've also adjusted the following:

- Changed the default "rock" color to be slightly lighter than walls
- Added `redrawCanvas()` for use when first loading the map _and_ adjusting map size
- Renamed `rotateRight()` and `rotateLeft()` to `rotateClockwise()` and `rotateCounterClockwise()` respectively